### PR TITLE
NFS-2658 - Set options to config boleto margin

### DIFF
--- a/lib/boleto.js
+++ b/lib/boleto.js
@@ -102,7 +102,8 @@ Boleto.prototype.renderHTML = async function () {
 
 Boleto.prototype.getPDFBuffer = async function (html) {
   try {
-    const stream = wkhtmltopdf(html, { encoding: 'utf-8', printMediaType: true })
+    const stream = wkhtmltopdf(html, { encoding: 'utf-8', printMediaType: true,
+      marginTop: "13", marginRight: "13", marginBottom: "13", marginLeft: "13", zoom: 1.5 })
     const chunks = []
     return await new Promise((resolve, reject) => {
       stream


### PR DESCRIPTION
Esta PR adiciona as options para configurar a posição do boleto na página do PDF. As margens foram setadas para 13mm, o equivalente aproximado de 50px, que era a configuração anterior.

Foi necessário setar a opção zoom para 1.5 pois o boleto ficava centralizado, porém menor que o esperado.